### PR TITLE
Make Makefile more portable

### DIFF
--- a/Examples/BasicExample/.swiftpm/build-and-run.sh
+++ b/Examples/BasicExample/.swiftpm/build-and-run.sh
@@ -2,6 +2,6 @@
 set -e
 killall 'Playdate Simulator' || true
 cd ..
-PRODUCT=$(sed -n '/^PRODUCT :=/s///p' Makefile)
+PRODUCT=$(make product_path | tail -n1)
 make 
 ~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator $PRODUCT

--- a/Examples/BasicExample/Makefile
+++ b/Examples/BasicExample/Makefile
@@ -1,21 +1,33 @@
+# Declares the root of the repository.
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
-PRODUCT := build/BasicExample.pdx
+
+# Declares where PlaydateKit is stored. In this example, PDKIT_ROOT is the
+# same as REPO_ROOT. In some setups and projects, this may differ.
+PDKIT_ROOT := $(shell git rev-parse --show-toplevel)
+
+# Declares information about the product being build. PRODUCT_NAME will
+# likely be the name of the Swift package or game where the source code
+# lives. PRODUCT points to where the build Playdate package file (pdx)
+# will be stored.
+PRODUCT_NAME := BasicExample
+PRODUCT := build/$(PRODUCT_NAME).pdx
+
 include $(REPO_ROOT)/Examples/swift.mk
 
 # MARK: - Build PlaydateKit Swift Module
-build/Modules/playdatekit_device.o: $(REPO_ROOT)/Sources/PlaydateKit/*.swift
+build/Modules/playdatekit_device.o: $(PDKIT_ROOT)/Sources/PlaydateKit/*.swift
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@
 
-build/Modules/playdatekit_simulator.o: $(REPO_ROOT)/Sources/PlaydateKit/*.swift
+build/Modules/playdatekit_simulator.o: $(PDKIT_ROOT)/Sources/PlaydateKit/*.swift
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -emit-module -o $@
 
 # MARK: - Build BasicExample Swift Object
-build/basicexample_device.o: Sources/BasicExample/*.swift | build/Modules/playdatekit_device.o
+build/basicexample_device.o: Sources/$(PRODUCT_NAME)/*.swift | build/Modules/playdatekit_device.o
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -o $@
 $(OBJDIR)/pdex.elf: build/basicexample_device.o
 OBJS += build/basicexample_device.o
 
-build/basicexample_simulator.o: Sources/BasicExample/*.swift | build/Modules/playdatekit_simulator.o
+build/basicexample_simulator.o: Sources/$(PRODUCT_NAME)/*.swift | build/Modules/playdatekit_simulator.o
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -o $@
 $(OBJDIR)/pdex.${DYLIB_EXT}: build/basicexample_simulator.o
 SIMCOMPILER += build/basicexample_simulator.o

--- a/Examples/BasicExample/Makefile
+++ b/Examples/BasicExample/Makefile
@@ -1,4 +1,7 @@
-# Declares the root of the repository.
+# Declares the root of the repository the game source code lives in. Most
+# of the time, the Makefile should already be at the root, and this may
+# not be needed. However, this can be adjusted if the source code lives
+# elsewhere.
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
 # Declares where PlaydateKit is stored. In this example, PDKIT_ROOT is the

--- a/Examples/BasicExample/Makefile
+++ b/Examples/BasicExample/Makefile
@@ -17,6 +17,12 @@ PRODUCT := build/$(PRODUCT_NAME).pdx
 
 include $(PDKIT_ROOT)/Examples/swift.mk
 
+# This is used to echo out the product path based on PRODUCT_NAME.
+product_path:
+	echo $(PRODUCT)
+	
+.PHONY: product_path
+
 # MARK: - Build PlaydateKit Swift Module
 build/Modules/playdatekit_device.o: $(PDKIT_ROOT)/Sources/PlaydateKit/*.swift
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@

--- a/Examples/BasicExample/Makefile
+++ b/Examples/BasicExample/Makefile
@@ -12,7 +12,7 @@ PDKIT_ROOT := $(shell git rev-parse --show-toplevel)
 PRODUCT_NAME := BasicExample
 PRODUCT := build/$(PRODUCT_NAME).pdx
 
-include $(REPO_ROOT)/Examples/swift.mk
+include $(PDKIT_ROOT)/Examples/swift.mk
 
 # MARK: - Build PlaydateKit Swift Module
 build/Modules/playdatekit_device.o: $(PDKIT_ROOT)/Sources/PlaydateKit/*.swift


### PR DESCRIPTION
To help make the Makefile more portable for different projects, the PlaydateKit path is now extracted to `PDKIT_ROOT`, as it may not always be the same as `REPO_ROOT`. `PRODUCT_NAME` was also introduced to make changing the source paths for game source code easier, and `PRODUCT` uses `PRODUCT_NAME` to its advantage.

Documentation on these variables is provided as comments here. In the future, command line tools can help set these variables automatically (such as with CMake) to automatically generate this Makefile.
