### PR TITLE
Public init for Graphics.Font

### DIFF
--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -298,7 +298,7 @@ public enum Graphics {
 
         /// Returns a `Font` object for the font file at `path`.
         /// > Warning: Currently unsafe due to https://github.com/finnvoor/PlaydateKit/issues/7
-        init(path: StaticString) {
+        public init(path: StaticString) {
             var error: UnsafePointer<CChar>?
             let pointer = graphics.loadFont(path.utf8Start, &error)
             self.pointer = pointer.unsafelyUnwrapped

--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -306,7 +306,7 @@ public enum Graphics {
 
         /// Returns a `Font` object for the font file at `path`.
         /// > Warning: Currently unsafe due to https://github.com/finnvoor/PlaydateKit/issues/7
-        init(path: UnsafeMutablePointer<CChar>) {
+        public init(path: UnsafeMutablePointer<CChar>) {
             var error: UnsafePointer<CChar>?
             let pointer = graphics.loadFont.unsafelyUnwrapped(path, &error)
             self.pointer = pointer.unsafelyUnwrapped
@@ -316,7 +316,7 @@ public enum Graphics {
         /// of an uncompressed pft file. `wide` corresponds to the flag in the header indicating whether the font contains
         /// glyphs at codepoints above U+1FFFF.
         /// > Warning: Currently unsafe due to https://github.com/finnvoor/PlaydateKit/issues/7
-        init(data: OpaquePointer, wide: Bool) {
+        public init(data: OpaquePointer, wide: Bool) {
             let pointer = graphics.makeFontFromData.unsafelyUnwrapped(data, wide ? 1 : 0)
             self.pointer = pointer.unsafelyUnwrapped
         }


### PR DESCRIPTION
🥔
I use text as sprites in my prototypes so this allows me to instantiate a custom Font. Let me know if I'm missing something and should be done in another way!