### PR TITLE
Fix crash when .realloc() returns nil

### DIFF
--- a/Sources/PlaydateKit/Core/System.swift
+++ b/Sources/PlaydateKit/Core/System.swift
@@ -218,8 +218,8 @@ public enum System {
     @discardableResult public static func realloc(
         pointer: UnsafeMutableRawPointer?,
         size: Int
-    ) -> UnsafeMutableRawPointer {
-        system.realloc.unsafelyUnwrapped(pointer, size).unsafelyUnwrapped
+    ) -> UnsafeMutableRawPointer? {
+        system.realloc.unsafelyUnwrapped(pointer, size)
     }
 
     // MARK: - Logging


### PR DESCRIPTION
If you pass size=0, it's a synonym for calling free(), and returns nil in this case.