### PR TITLE
Fix typo

### DIFF
--- a/Sources/PlaydateKit/Core/File.swift
+++ b/Sources/PlaydateKit/Core/File.swift
@@ -63,7 +63,7 @@ public enum File {
             buffer: UnsafeRawBufferPointer
         ) throws(Playdate.Error) -> CInt {
             let writtenCount = file.write.unsafelyUnwrapped(pointer, buffer.baseAddress, CUnsignedInt(buffer.count))
-            guard writtenCount != 1 else { throw lastError }
+            guard writtenCount != -1 else { throw lastError }
             return writtenCount
         }
 


### PR DESCRIPTION
This throws an error if only a single byte is written.