### PR TITLE
Split the stencil's public getter from the private setter.

### DIFF
--- a/Sources/PlaydateKit/Core/Sprite.swift
+++ b/Sources/PlaydateKit/Core/Sprite.swift
@@ -81,8 +81,14 @@ public enum Sprite {
         // MARK: Public
 
         /// The sprite's stencil bitmap, if set.
-        public private(set) var stencil: Graphics.Bitmap?
-
+        
+        
+        // I don't know why previous public private(set) var stencil
+        // was causing this kind of error https://github.com/finnvoor/PlaydateKit/issues/51
+        // Separating the public getter from ste private storage, resolved the issue
+        private var _stencil: Graphics.Bitmap?
+        public var stencil: Graphics.Bitmap? { _stencil }
+        
         /// The bitmap currently assigned to the sprite.
         public var image: Graphics.Bitmap? {
             didSet {
@@ -203,7 +209,7 @@ public enum Sprite {
         /// Specifies a stencil image to be set on the frame buffer before the sprite is drawn.
         /// Pass `nil` to clear the sprite’s stencil.
         public func setStencil(_ stencil: Graphics.Bitmap?) {
-            self.stencil = stencil
+            self._stencil = stencil
             if let stencil {
                 sprite.setStencil.unsafelyUnwrapped(pointer, stencil.pointer)
             } else {
@@ -214,14 +220,14 @@ public enum Sprite {
         /// Specifies a stencil image to be set on the frame buffer before the sprite is drawn. If `tile` is set, the stencil will be tiled.
         /// Tiled stencils must have width evenly divisible by 32.
         public func setStencilImage(_ stencil: Graphics.Bitmap, tile: CInt) {
-            self.stencil = stencil
+            self._stencil = stencil
             sprite.setStencilImage.unsafelyUnwrapped(pointer, stencil.pointer, tile)
         }
 
         /// Sets the sprite’s stencil to the given pattern.
         public func setStencilPattern(_ pattern: UnsafeMutablePointer<UInt8>) {
             sprite.setStencilPattern.unsafelyUnwrapped(pointer, pattern)
-            stencil = nil
+            _stencil = nil
         }
 
         /// Sets the clipping rectangle for sprite drawing.


### PR DESCRIPTION
Resolve #51.
The error was very weird, and apparently without any valid reason.
After some attempts I finally managed to resolve the issue (but still not know why it appeared).