### PR TITLE
Fix `Graphics.fillPolygon()` Artifacting

### DIFF
--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -737,7 +737,7 @@ public enum Graphics {
     ) {
         color.withLCDColor {
             var points = polygon.vertices.flatMap { [$0.x, $0.y] }
-            graphics.fillPolygon.unsafelyUnwrapped(CInt(points.count), &points, $0, fillRule)
+            graphics.fillPolygon.unsafelyUnwrapped(CInt(points.count / 2), &points, $0, fillRule)
         }
     }
 


### PR DESCRIPTION
(👋 This is my first contribution to the repository and I believe I've read up but please let me know if I've missed any rules/guidelines/instructions or anything else I should do for this pull request, thank you!)

### Description
`Graphics.fillPolygon()` accepts the polygon, maps the `Point`s into a `CInt` array of `[x1, y1, x2, y2, ...]`. I believe a small issue in the count passed as the first argument to the Playdate C API is causing draw artifacting.

The C API accepts `nPoints` as the first argument (a.k.a "number of points") but instead what is being passed is number of integers. In other words, this should be divided by two.

### Reproduction
I've created a simple reproduction in a branch [here](https://github.com/tyetrask/PlaydateKitTemplateTests/tree/poly-vert-count-repro) but the example can be seen pretty easily with a `Game` implementation like follows:
```Swift
final class Game: PlaydateGame {
    func update() -> Bool {
        Graphics.clear(color: .black)
        let poly = Polygon<CInt>(vertices: [
            Point(x: 200, y: 200),
            Point(x: 210, y: 200),
            Point(x: 210, y: 210),
            Point(x: 200, y: 210)
        ])
        Graphics.fillPolygon(poly, color: .white, fillRule: .nonZero)
        
        System.drawFPS()
        return true
    }
}
```

### Current Behavior
With latest `main` for PlaydateKit, this produces the following:

![poly_bug](https://github.com/finnvoor/PlaydateKit/assets/4699263/6b30e453-7c01-496b-8d98-30590ad1c193)

### Expected Behavior
With the change included in this pull request, the same code produces the following:

![poly_expected](https://github.com/finnvoor/PlaydateKit/assets/4699263/8d98d8f4-e09c-44d1-a2bd-38a1e7a10407)