### PR TITLE
Implement putchar (sort of)

### DIFF
--- a/Sources/PlaydateKit/Core/System.swift
+++ b/Sources/PlaydateKit/Core/System.swift
@@ -236,7 +236,7 @@ public enum System {
 
     /// Calls the log function, outputting an error in red to the console, then pauses execution.
     public static func error(_ error: Playdate.Error) {
-        System.error(error.humanReadableText ?? "")
+        System.error(error.humanReadableText)
     }
 
     /// Calls the log function.


### PR DESCRIPTION
`putchar` is required to use `print` in Embedded Swift. Since there is no way to log to the Playdate console without adding a newline to the end (see [here](https://devforum.play.date/t/logtoconsole-without-a-linebreak/1819)), this PR implements `putchar` by storing characters in a temporary buffer and only printing them once a newline is received (the default terminator to `print`).

If/when the C API is updated to support logging without a newline this will be improved.

closes #41 