### PR TITLE
Preserve path when copying resources

### DIFF
--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -73,7 +73,7 @@ struct ModuleBuildRequest {
         let playdateKitSwiftFiles = playdateKitSource.sourceFiles(withSuffix: "swift").map(\.path.string)
         let cPlaydateInclude = playdateKitPackage.package.sourceModules
             .first(where: { $0.name == "CPlaydate" })!.directory.appending("include")
-
+            
         let productSource = context.package.sourceModules.first!
         let productSwiftFiles = productSource.sourceFiles(withSuffix: "swift").map(\.path.string)
         let productResources = productSource.sourceFiles
@@ -219,11 +219,24 @@ struct ModuleBuildRequest {
             atPath: sourcePath.string,
             withIntermediateDirectories: true
         )
-        print("copying resources")
+        
+        print("copying resources...")
         for resource in productResources {
+            let relativePath = resource.string
+                .replacingOccurrences(of: productSource.directory.string + "/", with: "")
+            let dest = sourcePath.appending([relativePath])
+            let destDirectory = dest.removingLastComponent()
+            var isDirectory: ObjCBool = false
+            
+            if !FileManager.default.fileExists(atPath: destDirectory.string, isDirectory: &isDirectory) {
+                print("creating \(destDirectory.string) directory")
+                try FileManager.default.createDirectory(atPath: destDirectory.string, withIntermediateDirectories: true)
+            }
+            
+            print("copying \(relativePath)")
             try FileManager.default.copyItem(
                 atPath: resource.string,
-                toPath: sourcePath.appending([resource.lastComponent]).string
+                toPath: dest.string
             )
         }
 


### PR DESCRIPTION
This change will let preserve relative path of all assets and not copy them to root folder

This change also would require to put pdxinfo in root of source code and therefore update template repository. May be we should introduce assets folder and pass it as an argument to PDC plugin?