### PR TITLE
Switch all geometry types to single float version

### DIFF
--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -166,8 +166,8 @@ public enum Graphics {
         /// Gets the color of the pixel at `point` in the bitmap. If the coordinate is outside the bounds
         /// of the bitmap, or if the bitmap has a mask and the pixel is marked transparent, the function
         /// returns clear; otherwise the return value is white or black.
-        public func getPixel(at point: Point<CInt>) -> Color {
-            .solid(graphics.getBitmapPixel(pointer, point.x, point.y))
+        public func getPixel(at point: Point) -> Color {
+            .solid(graphics.getBitmapPixel(pointer, CInt(point.x), CInt(point.y)))
         }
 
         /// Returns a new, rotated and scaled `Bitmap` based on the given `bitmap`.
@@ -442,13 +442,23 @@ public enum Graphics {
 
     /// Sets the current clip rect, using world coordinates—​that is, the given rectangle will be translated by
     /// the current drawing offset. The clip rect is cleared at the beginning of each update.
-    public static func setClipRect(_ rect: Rect<CInt>) {
-        graphics.setClipRect.unsafelyUnwrapped(rect.x, rect.y, rect.width, rect.height)
+    public static func setClipRect(_ rect: Rect) {
+        graphics.setClipRect.unsafelyUnwrapped(
+            CInt(rect.x),
+            CInt(rect.y),
+            CInt(rect.width),
+            CInt(rect.height)
+        )
     }
 
     /// Sets the current clip rect in screen coordinates.
-    public static func setScreenClipRect(_ rect: Rect<CInt>) {
-        graphics.setScreenClipRect.unsafelyUnwrapped(rect.x, rect.y, rect.width, rect.height)
+    public static func setScreenClipRect(_ rect: Rect) {
+        graphics.setScreenClipRect.unsafelyUnwrapped(
+            CInt(rect.x),
+            CInt(rect.y),
+            CInt(rect.width),
+            CInt(rect.height)
+        )
     }
 
     /// Clears the current clip rect.
@@ -476,43 +486,43 @@ public enum Graphics {
     /// if no pixels overlap or if one or both fall completely outside of rect.
     public static func checkMaskCollision(
         bitmap1: Bitmap,
-        point1: Point<CInt>,
+        point1: Point,
         flip1: Bitmap.Flip,
         bitmap2: Bitmap,
-        point2: Point<CInt>,
+        point2: Point,
         flip2: Bitmap.Flip,
-        rect: Rect<CInt>
+        rect: Rect
     ) -> Bool {
         graphics.checkMaskCollision.unsafelyUnwrapped(
             bitmap1.pointer,
-            point1.x,
-            point1.y,
+            CInt(point1.x),
+            CInt(point1.y),
             flip1,
             bitmap2.pointer,
-            point2.x,
-            point2.y,
+            CInt(point2.x),
+            CInt(point2.y),
             flip2,
             rect.lcdRect
         ) != 0
     }
 
     /// Draws the `bitmap` with its upper-left corner at location `point`, using the given `flip` orientation.
-    public static func drawBitmap(_ bitmap: Bitmap, at point: Point<CInt>, flip: Bitmap.Flip) {
-        graphics.drawBitmap.unsafelyUnwrapped(bitmap.pointer, point.x, point.y, flip)
+    public static func drawBitmap(_ bitmap: Bitmap, at point: Point, flip: Bitmap.Flip) {
+        graphics.drawBitmap.unsafelyUnwrapped(bitmap.pointer, CInt(point.x), CInt(point.y), flip)
     }
 
     /// Draws the `bitmap` scaled to `xScale` and `yScale` with its upper-left corner at location `point`.
     /// Note that `flip` is not available when drawing scaled bitmaps but negative scale values will achieve the same effect.
     public static func drawBitmap(
         _ bitmap: Bitmap,
-        at point: Point<CInt>,
+        at point: Point,
         xScale: Float = 1,
         yScale: Float = 1
     ) {
         graphics.drawScaledBitmap.unsafelyUnwrapped(
             bitmap.pointer,
-            point.x,
-            point.y,
+            CInt(point.x),
+            CInt(point.y),
             xScale,
             yScale
         )
@@ -523,16 +533,16 @@ public enum Graphics {
     /// if `center` is (0, 0) the top left corner of the image (before rotation) is at (point.x, point.y), etc.
     public static func drawBitmap(
         _ bitmap: Bitmap,
-        at point: Point<CInt>,
+        at point: Point,
         degrees: Float,
-        center: Point<Float>,
+        center: Point,
         xScale: Float = 1,
         yScale: Float = 1
     ) {
         graphics.drawRotatedBitmap.unsafelyUnwrapped(
             bitmap.pointer,
-            point.x,
-            point.y,
+            CInt(point.x),
+            CInt(point.y),
             degrees,
             center.x,
             center.y,
@@ -544,15 +554,15 @@ public enum Graphics {
     /// Draws the `bitmap` tiled inside `rect`.
     public static func tileBitmap(
         _ bitmap: Bitmap,
-        inside rect: Rect<CInt>,
+        inside rect: Rect,
         flip: Bitmap.Flip
     ) {
         graphics.tileBitmap.unsafelyUnwrapped(
             bitmap.pointer,
-            rect.x,
-            rect.y,
-            rect.width,
-            rect.height,
+            CInt(rect.x),
+            CInt(rect.y),
+            CInt(rect.width),
+            CInt(rect.height),
             flip
         )
     }
@@ -563,14 +573,14 @@ public enum Graphics {
     /// Returns the drawn width of the given `text`.
     @discardableResult public static func drawText(
         _ text: String,
-        at point: Point<CInt>
+        at point: Point
     ) -> CInt {
         graphics.drawText.unsafelyUnwrapped(
             text,
             text.utf8.count,
             .kUTF8Encoding,
-            point.x,
-            point.y
+            CInt(point.x),
+            CInt(point.y)
         )
     }
 
@@ -578,7 +588,7 @@ public enum Graphics {
     /// If `startAngle` != `endAngle`, this draws an arc between the given angles.
     /// Angles are given in degrees, clockwise from due north.
     public static func drawEllipse(
-        in rect: Rect<CInt>,
+        in rect: Rect,
         lineWidth: CInt = 1,
         startAngle: Float = 0,
         endAngle: Float = 360,
@@ -586,10 +596,10 @@ public enum Graphics {
     ) {
         color.withLCDColor {
             graphics.drawEllipse.unsafelyUnwrapped(
-                rect.x,
-                rect.y,
-                rect.width,
-                rect.height,
+                CInt(rect.x),
+                CInt(rect.y),
+                CInt(rect.width),
+                CInt(rect.height),
                 lineWidth,
                 startAngle,
                 endAngle,
@@ -601,17 +611,17 @@ public enum Graphics {
     /// Fills an ellipse inside the rectangle `rect`. If `startAngle` != `endAngle`, this draws a
     /// wedge/Pacman between the given angles. Angles are given in degrees, clockwise from due north.
     public static func fillEllipse(
-        in rect: Rect<CInt>,
+        in rect: Rect,
         startAngle: Float = 0,
         endAngle: Float = 360,
         color: Color = .black
     ) {
         color.withLCDColor {
             graphics.fillEllipse.unsafelyUnwrapped(
-                rect.x,
-                rect.y,
-                rect.width,
-                rect.height,
+                CInt(rect.x),
+                CInt(rect.y),
+                CInt(rect.width),
+                CInt(rect.height),
                 startAngle,
                 endAngle,
                 $0
@@ -621,16 +631,16 @@ public enum Graphics {
 
     /// Draws `line` with a stroke width of `lineWidth` and color `color`.
     public static func drawLine(
-        _ line: Line<CInt>,
+        _ line: Line,
         lineWidth: CInt = 1,
         color: Color = .black
     ) {
         color.withLCDColor {
             graphics.drawLine.unsafelyUnwrapped(
-                line.start.x,
-                line.start.y,
-                line.end.x,
-                line.end.y,
+                CInt(line.start.x),
+                CInt(line.start.y),
+                CInt(line.end.x),
+                CInt(line.end.y),
                 lineWidth,
                 $0
             )
@@ -639,25 +649,31 @@ public enum Graphics {
 
     /// Draws a `rect` with the specified `color`.
     public static func drawRect(
-        _ rect: Rect<CInt>,
+        _ rect: Rect,
         color: Color = .black
     ) {
         color.withLCDColor {
-            graphics.drawRect.unsafelyUnwrapped(rect.x, rect.y, rect.width, rect.height, $0)
+            graphics.drawRect.unsafelyUnwrapped(
+                CInt(rect.x),
+                CInt(rect.y),
+                CInt(rect.width),
+                CInt(rect.height),
+                $0
+            )
         }
     }
 
     /// Draws a `rect` filled with the specified `color`
     public static func fillRect(
-        _ rect: Rect<CInt>,
+        _ rect: Rect,
         color: Color = .black
     ) {
         color.withLCDColor {
             graphics.fillRect.unsafelyUnwrapped(
-                rect.x,
-                rect.y,
-                rect.width,
-                rect.height,
+                CInt(rect.x),
+                CInt(rect.y),
+                CInt(rect.width),
+                CInt(rect.height),
                 $0
             )
         }
@@ -665,19 +681,19 @@ public enum Graphics {
 
     /// Draws a filled triangle with points at `p1`, `p2`, and `p3`.
     public static func fillTriangle(
-        p1: Point<CInt>,
-        p2: Point<CInt>,
-        p3: Point<CInt>,
+        p1: Point,
+        p2: Point,
+        p3: Point,
         color: Color = .black
     ) {
         color.withLCDColor {
             graphics.fillTriangle.unsafelyUnwrapped(
-                p1.x,
-                p1.y,
-                p2.x,
-                p2.y,
-                p3.x,
-                p3.y,
+                CInt(p1.x),
+                CInt(p1.y),
+                CInt(p2.x),
+                CInt(p2.y),
+                CInt(p3.x),
+                CInt(p3.y),
                 $0
             )
         }
@@ -687,12 +703,12 @@ public enum Graphics {
     /// See https://en.wikipedia.org/wiki/Nonzero-rule for an explanation of the winding rule.
     /// An edge between the last vertex and the first is assumed.
     public static func fillPolygon(
-        _ polygon: Polygon<CInt>,
+        _ polygon: Polygon,
         color: Color = .black,
         fillRule: PolygonFillRule
     ) {
         color.withLCDColor {
-            var points = polygon.vertices.flatMap { [$0.x, $0.y] }
+            var points = polygon.vertices.flatMap { [CInt($0.x), CInt($0.y)] }
             graphics.fillPolygon.unsafelyUnwrapped(CInt(points.count / 2), &points, $0, fillRule)
         }
     }
@@ -758,18 +774,18 @@ public enum Graphics {
     }
 
     /// Returns a color using an 8 x 8 pattern using the given `bitmap`. `topLeft` indicates the top left corner of the 8 x 8 pattern.
-    public static func colorFromPattern(_ pattern: Bitmap, topLeft: Point<CInt> = .zero) -> LCDColor {
+    public static func colorFromPattern(_ pattern: Bitmap, topLeft: Point = .zero) -> LCDColor {
         var color: LCDColor = 0
-        graphics.setColorToPattern.unsafelyUnwrapped(&color, pattern.pointer, topLeft.x, topLeft.y)
+        graphics.setColorToPattern.unsafelyUnwrapped(&color, pattern.pointer, CInt(topLeft.x), CInt(topLeft.y))
         return color
     }
 
     /// Sets the pixel at `point` in the current drawing context (by default the screen) to the given color.
     /// Be aware that setting a pixel at a time is not very efficient: In our testing, more than around 20,000
     /// calls in a tight loop will drop the frame rate below 30 fps.
-    public static func setPixel(at point: Point<CInt>, to color: Color) {
+    public static func setPixel(at point: Point, to color: Color) {
         color.withLCDColor {
-            graphics.setPixel(point.x, point.y, $0)
+            graphics.setPixel(CInt(point.x), CInt(point.y), $0)
         }
     }
 

--- a/Sources/PlaydateKit/Core/Sprite.swift
+++ b/Sources/PlaydateKit/Core/Sprite.swift
@@ -67,7 +67,7 @@ public enum Sprite {
         /// If the sprite doesn’t have an image, the sprite’s draw function is called as needed to update the display. Note that this method
         /// is only called when the sprite is on screen and has a size specified via ``setSize(width:height:)`` or ``bounds``.
         /// > Warning: This currently does not work due to [apple/swift/issues/72626](https://github.com/apple/swift/issues/72626)
-        @available(*, unavailable) open func draw(bounds _: Rect<Float>, drawRect _: Rect<Float>) {}
+        @available(*, unavailable) open func draw(bounds _: Rect, drawRect _: Rect) {}
 
         /// Override to control the type of collision response that should happen when a collision with other occurs.
         ///
@@ -91,14 +91,14 @@ public enum Sprite {
         }
 
         /// Gets the current position of sprite.
-        public var position: Point<Float> {
+        public var position: Point {
             var x: Float = 0, y: Float = 0
             sprite.getPosition.unsafelyUnwrapped(pointer, &x, &y)
             return Point(x: x, y: y)
         }
 
         /// Gets/sets the bounds of the sprite.
-        public var bounds: Rect<Float> {
+        public var bounds: Rect {
             get { Rect(sprite.getBounds.unsafelyUnwrapped(pointer)) }
             set { sprite.setBounds.unsafelyUnwrapped(pointer, newValue.pdRect) }
         }
@@ -107,7 +107,7 @@ public enum Sprite {
         /// Default is 0.5, 0.5 (the center of the sprite).
         /// This means that when you call `moveTo(x, y)`, the center of your sprite will be positioned at x, y.
         /// If you want x and y to represent the upper left corner of your sprite, specify the center as 0, 0.
-        public var center: Point<Float> {
+        public var center: Point {
             get {
                 var x: Float = 0, y: Float = 0
                 sprite.getCenter.unsafelyUnwrapped(pointer, &x, &y)
@@ -155,7 +155,7 @@ public enum Sprite {
         }
 
         /// Marks the area of the given sprite, relative to its bounds, to be checked for collisions with other sprites' collide rects.
-        public var collideRect: Rect<Float>? {
+        public var collideRect: Rect? {
             get { Rect(sprite.getCollideRect.unsafelyUnwrapped(pointer)) }
             set {
                 if let newValue {
@@ -181,7 +181,7 @@ public enum Sprite {
         }
 
         /// Moves the sprite to `point` and resets its bounds based on the bitmap dimensions and center.
-        public func moveTo(_ point: Point<Float>) {
+        public func moveTo(_ point: Point) {
             sprite.moveTo.unsafelyUnwrapped(pointer, point.x, point.y)
         }
 
@@ -226,7 +226,7 @@ public enum Sprite {
 
         /// Sets the clipping rectangle for sprite drawing.
         /// Pass `nil` to clear the sprite’s clipping rectangle.
-        public func setClipRect(_ clipRect: Rect<CInt>?) {
+        public func setClipRect(_ clipRect: Rect?) {
             if let clipRect {
                 sprite.setClipRect.unsafelyUnwrapped(pointer, clipRect.lcdRect)
             } else {
@@ -284,7 +284,7 @@ public enum Sprite {
         /// Moves the given sprite towards `goal` taking collisions into account and returns an array of `SpriteCollisionInfo`.
         /// `actualX`, `actualY` are set to the sprite’s position after collisions. If no collisions occurred, this will be the same as
         /// `goalX`, `goalY`.
-        public func moveWithCollisions(goal: Point<Float>) -> CollisionInfo {
+        public func moveWithCollisions(goal: Point) -> CollisionInfo {
             var actualX: Float = 0, actualY: Float = 0
             var length: CInt = 0
             let collisionInfo = sprite.moveWithCollisions.unsafelyUnwrapped(
@@ -355,7 +355,7 @@ public enum Sprite {
     public class CollisionInfo {
         // MARK: Lifecycle
 
-        init(collisions: UnsafeBufferPointer<SpriteCollisionInfo>, actual: Point<Float>) {
+        init(collisions: UnsafeBufferPointer<SpriteCollisionInfo>, actual: Point) {
             self.collisions = collisions
             self.actual = actual
         }
@@ -365,7 +365,7 @@ public enum Sprite {
         // MARK: Public
 
         public let collisions: UnsafeBufferPointer<SpriteCollisionInfo>
-        public let actual: Point<Float>
+        public let actual: Point
     }
 
     public class QueryInfo {
@@ -387,7 +387,7 @@ public enum Sprite {
     // MARK: - Properties
 
     /// Sets the clipping rectangle for all sprites with a Z index within `startZ` and `endZ` inclusive.
-    public static func setClipRectsInRange(clipRect: Rect<CInt>, startZ: CInt, endZ: CInt) {
+    public static func setClipRectsInRange(clipRect: Rect, startZ: CInt, endZ: CInt) {
         sprite.setClipRectsInRange.unsafelyUnwrapped(clipRect.lcdRect, startZ, endZ)
     }
 
@@ -405,7 +405,7 @@ public enum Sprite {
 
     /// Marks the given dirtyRect (in screen coordinates) as needing a redraw. Graphics drawing functions now call this
     /// automatically, adding their drawn areas to the sprite’s dirty list, so there’s usually no need to call this manually.
-    public static func addDirtyRect(_ dirtyRect: Rect<CInt>) {
+    public static func addDirtyRect(_ dirtyRect: Rect) {
         sprite.addDirtyRect.unsafelyUnwrapped(dirtyRect.lcdRect)
     }
 
@@ -446,7 +446,7 @@ public enum Sprite {
 
     /// Returns an array of all sprites with collision rects containing `point`.
     /// > Warning: The caller is responsible for freeing the returned array.
-    public static func querySpritesAtPoint(_ point: Point<Float>) -> UnsafeBufferPointer<OpaquePointer?> {
+    public static func querySpritesAtPoint(_ point: Point) -> UnsafeBufferPointer<OpaquePointer?> {
         var length: CInt = 0
         let sprites = sprite.querySpritesAtPoint.unsafelyUnwrapped(point.x, point.y, &length)
         return UnsafeBufferPointer(start: sprites, count: Int(length))
@@ -454,7 +454,7 @@ public enum Sprite {
 
     /// Returns an array of all sprites with collision rects that intersect `rect`.
     /// > Warning: The caller is responsible for freeing the returned array.
-    public static func querySpritesInRect(_ rect: Rect<Float>) -> UnsafeBufferPointer<OpaquePointer?> {
+    public static func querySpritesInRect(_ rect: Rect) -> UnsafeBufferPointer<OpaquePointer?> {
         var length: CInt = 0
         let sprites = sprite.querySpritesInRect.unsafelyUnwrapped(
             rect.x,
@@ -468,7 +468,7 @@ public enum Sprite {
 
     /// Returns an array of all sprites with collision rects that intersect `line`.
     /// > Warning: The caller is responsible for freeing the returned array.
-    public static func querySpritesAlongLine(_ line: Line<Float>) -> UnsafeBufferPointer<OpaquePointer?> {
+    public static func querySpritesAlongLine(_ line: Line) -> UnsafeBufferPointer<OpaquePointer?> {
         var length: CInt = 0
         let sprites = sprite.querySpritesAlongLine.unsafelyUnwrapped(
             line.start.x,
@@ -482,7 +482,7 @@ public enum Sprite {
 
     /// Returns an array of `SpriteQueryInfo` for all sprites with collision rects that intersect `line`.
     /// If you don’t need this information, use `querySpritesAlongLine()` as it will be faster.
-    public static func querySpriteInfoAlongLine(_ line: Line<Float>) -> QueryInfo {
+    public static func querySpriteInfoAlongLine(_ line: Line) -> QueryInfo {
         var length: CInt = 0
         let spriteInfo = sprite.querySpriteInfoAlongLine.unsafelyUnwrapped(
             line.start.x,

--- a/Sources/PlaydateKit/Core/System.swift
+++ b/Sources/PlaydateKit/Core/System.swift
@@ -386,8 +386,8 @@ public enum System {
     }
 
     /// Calculates the current frames per second and draws that value at `point`.
-    public static func drawFPS(at point: Point<CInt> = .zero) {
-        system.drawFPS.unsafelyUnwrapped(point.x, point.y)
+    public static func drawFPS(at point: Point = .zero) {
+        system.drawFPS.unsafelyUnwrapped(CInt(point.x), CInt(point.y))
     }
 
     /// Flush the CPU instruction cache, on the very unlikely chance you’re modifying instruction code on the fly.

--- a/Sources/PlaydateKit/Geometry/Line.swift
+++ b/Sources/PlaydateKit/Geometry/Line.swift
@@ -1,29 +1,27 @@
 // MARK: - Line
 
 /// A structure representing a line with a start and end point in a two-dimensional coordinate system.
-public struct Line<T: Numeric>: Equatable {
+public struct Line: Equatable {
     // MARK: Lifecycle
 
-    public init(start: Point<T>, end: Point<T>) {
+    public init(start: Point, end: Point) {
         self.start = start
         self.end = end
     }
 
     // MARK: Public
 
-    public var start, end: Point<T>
+    /// The line whose start and end are both located at (0, 0).
+    public static var zero: Line { Line(start: .zero, end: .zero) }
+
+    public var start, end: Point
 }
 
 // MARK: AffineTransformable
 
-extension Line: AffineTransformable where T == Float {
+extension Line: AffineTransformable {
     public mutating func transform(by transform: AffineTransform) {
         start.transform(by: transform)
         end.transform(by: transform)
     }
-}
-
-public extension Line {
-    /// The line whose start and end are both located at (0, 0).
-    static var zero: Line<T> { Line(start: .zero, end: .zero) }
 }

--- a/Sources/PlaydateKit/Geometry/Point.swift
+++ b/Sources/PlaydateKit/Geometry/Point.swift
@@ -1,30 +1,28 @@
 // MARK: - Point
 
 /// A structure that contains a point in a two-dimensional coordinate system.
-public struct Point<T: Numeric>: Equatable {
+public struct Point: Equatable {
     // MARK: Lifecycle
 
-    public init(x: T, y: T) {
+    public init(x: Float, y: Float) {
         self.x = x
         self.y = y
     }
 
     // MARK: Public
 
-    public var x, y: T
+    /// The point with location (0,0).
+    public static var zero: Point { Point(x: 0, y: 0) }
+
+    public var x, y: Float
 }
 
 // MARK: AffineTransformable
 
-extension Point: AffineTransformable where T == Float {
+extension Point: AffineTransformable {
     public mutating func transform(by transform: AffineTransform) {
         let newX = transform.m11 * x + transform.m12 * y + transform.tx
         let newY = transform.m21 * x + transform.m22 * y + transform.ty
         self = Point(x: newX, y: newY)
     }
-}
-
-public extension Point {
-    /// The point with location (0,0).
-    static var zero: Point<T> { Point(x: 0, y: 0) }
 }

--- a/Sources/PlaydateKit/Geometry/Polygon.swift
+++ b/Sources/PlaydateKit/Geometry/Polygon.swift
@@ -1,18 +1,18 @@
 // MARK: - Polygon
 
 /// A structure that contains a two-dimensional open or closed polygon.
-public struct Polygon<T: Numeric>: Equatable {
+public struct Polygon: Equatable {
     // MARK: Lifecycle
 
     /// Creates a polygon with the specified vertices.
-    public init(vertices: [Point<T>]) {
+    public init(vertices: [Point]) {
         self.vertices = vertices
     }
 
     // MARK: Public
 
     /// The polygon's vertices.
-    public var vertices: [Point<T>]
+    public var vertices: [Point]
 
     /// Returns true if the polygon is closed, false if not.
     public var isClosed: Bool { (vertices.first == vertices.last) && vertices.first != nil }
@@ -24,9 +24,9 @@ public struct Polygon<T: Numeric>: Equatable {
     }
 }
 
-// MARK: - Array + AffineTransformable
+// MARK: - AffineTransformable + AffineTransformable
 
-extension [Point<Float>]: AffineTransformable {
+extension [Point]: AffineTransformable {
     public mutating func transform(by transform: AffineTransform) {
         for i in indices {
             self[i].transform(by: transform)
@@ -36,7 +36,7 @@ extension [Point<Float>]: AffineTransformable {
 
 // MARK: - Polygon + AffineTransformable
 
-extension Polygon: AffineTransformable where T == Float {
+extension Polygon: AffineTransformable {
     public mutating func transform(by transform: AffineTransform) {
         vertices.transform(by: transform)
     }

--- a/Sources/PlaydateKit/Geometry/Rect.swift
+++ b/Sources/PlaydateKit/Geometry/Rect.swift
@@ -1,17 +1,17 @@
 // MARK: - Rect
 
 /// A structure that contains the location and dimensions of a rectangle.
-public struct Rect<T: Numeric>: Equatable {
+public struct Rect: Equatable {
     // MARK: Lifecycle
 
-    public init(x: T, y: T, width: T, height: T) {
+    public init(x: Float, y: Float, width: Float, height: Float) {
         self.x = x
         self.y = y
         self.width = width
         self.height = height
     }
 
-    public init(origin: Point<T>, width: T, height: T) {
+    public init(origin: Point, width: Float, height: Float) {
         x = origin.x
         y = origin.y
         self.width = width
@@ -20,12 +20,15 @@ public struct Rect<T: Numeric>: Equatable {
 
     // MARK: Public
 
-    public var x, y, width, height: T
+    /// The point with location (0,0).
+    public static var zero: Rect { Rect(x: 0, y: 0, width: 0, height: 0) }
+
+    public var x, y, width, height: Float
 }
 
 // MARK: AffineTransformable
 
-extension Rect: AffineTransformable where T == Float {
+extension Rect: AffineTransformable {
     public mutating func transform(by transform: AffineTransform) {
         let transformedOrigin = Point(x: x, y: y).transformed(by: transform)
         let transformedTopRight = Point(x: x + width, y: y + height).transformed(by: transform)
@@ -36,25 +39,24 @@ extension Rect: AffineTransformable where T == Float {
     }
 }
 
-public extension Rect {
-    /// The point with location (0,0).
-    static var zero: Rect<T> { Rect(x: 0, y: 0, width: 0, height: 0) }
-}
+// MARK: - Rect + LCDRect
 
-extension Rect where T == CInt {
+public extension Rect {
     var lcdRect: LCDRect {
-        LCDMakeRect(x, y, width, height)
+        LCDMakeRect(CInt(x), CInt(y), CInt(width), CInt(height))
     }
 
     init(_ lcdRect: LCDRect) {
-        x = lcdRect.left
-        y = lcdRect.top
-        width = lcdRect.right - lcdRect.left
-        height = lcdRect.bottom - lcdRect.top
+        x = Float(lcdRect.left)
+        y = Float(lcdRect.top)
+        width = Float(lcdRect.right) - Float(lcdRect.left)
+        height = Float(lcdRect.bottom) - Float(lcdRect.top)
     }
 }
 
-extension Rect where T == Float {
+// MARK: - Rect + PDRect
+
+public extension Rect {
     var pdRect: PDRect {
         PDRect(x: x, y: y, width: width, height: height)
     }


### PR DESCRIPTION
In practice having to use Int-based geometry when drawing to the screen is quite annoying, so now all geometry types are Float based and graphics functions round them to Ints.