### PR TITLE
Support for multiple package products

### DIFF
--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -45,6 +45,41 @@ struct ModuleBuildRequest {
         var arguments = ArgumentExtractor(arguments)
         let verbose = arguments.extractFlag(named: "verbose") > 0
 
+        // Find the product for the provided argument
+        var productModule: (any SourceModuleTarget)! = nil
+        if productModule == nil, let productNameArg = arguments.extractOption(named: "product").first {
+            if let argModule = context.package.products.first(where: {
+                return $0.name == productNameArg
+            })?.sourceModules.first {
+                productModule = argModule
+                print("Found product named \(productNameArg).")
+            }else{
+                // If the provided product was not found, error out
+                print("Failed to locate product named \(productNameArg).")
+                throw Error.productNotFound
+            }
+        }
+        // Find the first product most liekly to be a Playdate game
+        if productModule == nil {
+            if let searchedModule = context.package.products.first(where: {
+                $0.targets.first(where: {
+                    $0.dependencies.first(where: {
+                        if case .product(let product) = $0 {
+                            return product.name == "PlaydateKit"
+                        }
+                        return false
+                    }) != nil
+                }) != nil
+            })?.sourceModules.first {
+                productModule = searchedModule
+                print("Found product named \(productModule.name).")
+            }
+        }
+        if productModule == nil {
+            print("Failed to locate a suitable Package product.")
+            throw Error.productNotFound
+        }
+        
         // MARK: - Paths
 
         let swiftToolchain = try swiftToolchain()
@@ -78,7 +113,7 @@ struct ModuleBuildRequest {
         let cPlaydateInclude = playdateKitPackage.package.sourceModules
             .first(where: { $0.name == "CPlaydate" })!.directory.appending("include")
 
-        let productSource = context.package.sourceModules.first!
+        let productSource = productModule!
         let productSwiftFiles = productSource.sourceFiles(withSuffix: "swift").map(\.path.string)
 
         let playdateKit = ModuleBuildRequest(name: "playdatekit", type: .playdateKit, relativePath: modulesPath, sourcefiles: playdateKitSwiftFiles)
@@ -376,6 +411,7 @@ struct ModuleBuildRequest {
 
 extension PDCPlugin {
     enum Error: Swift.Error {
+        case productNotFound
         case swiftToolchainNotFound
         case playdateSDKNotFound
         case ccFailed(exitCode: Int32)

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -222,7 +222,7 @@ struct ModuleBuildRequest {
         )
 
         print("copying resources...")
-        // Create list or resources including a relative path
+        // Create a list of resources including the relative path
         var resourcePaths: [(path: String, relativePath: String)] = []
 
         // Scan package and dependencies for resources

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -244,8 +244,7 @@ struct ModuleBuildRequest {
             let dest = sourcePath.appending([resource.relativePath])
             let destDirectory = dest.removingLastComponent()
             
-            var isDirectory: ObjCBool = false
-            if !FileManager.default.fileExists(atPath: destDirectory.string, isDirectory: &isDirectory) {
+            if FileManager.default.fileExists(atPath: destDirectory.string, isDirectory: nil) == false {
                 let relativeDestDirectory = Path(resource.relativePath).removingLastComponent()
                 print("creating directory \(relativeDestDirectory.string)/")
                 try FileManager.default.createDirectory(atPath: destDirectory.string, withIntermediateDirectories: true)

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -97,7 +97,7 @@ struct ModuleBuildRequest {
         let moduleCachePath = context.pluginWorkDirectory.appending(["module-cache"])
         let modulesPath = context.pluginWorkDirectory.appending(["Modules"])
 
-        let sourcePath = context.pluginWorkDirectory.appending(["Source"])
+        let sourcePath = context.pluginWorkDirectory.appending(["\(productName)-Source"])
         let productPath: String = if let targetBuildDir = ProcessInfo.processInfo.environment["TARGET_BUILD_DIR"] {
             // Run from Xcode
             targetBuildDir + "/\(productName).pdx"

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -92,7 +92,7 @@ struct ModuleBuildRequest {
         ))?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "???"
         print("found Playdate SDK (\(playdateSDKVersion))")
 
-        let productName = context.package.displayName
+        let productName = productModule.name
 
         let moduleCachePath = context.pluginWorkDirectory.appending(["module-cache"])
         let modulesPath = context.pluginWorkDirectory.appending(["Modules"])

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -253,7 +253,7 @@ struct ModuleBuildRequest {
             
             // If the resource is pdxinfo, always place it in the pdx root
             var destination = dest.string
-            if resource.path.hasSuffix("pdxinfo") {
+            if resource.path.hasSuffix("/pdxinfo") {
                 destination = sourcePath.appending(["pdxinfo"]).string
             }
             


### PR DESCRIPTION
These changes allow a package to have more than one package product.
This will allow users to build multiple games or create a simple playground game to test things in.
This will also make unrelated products ignored so the package can have products for build tools etc...

PDCPlugin now takes an optional --product argument. 
-When the argument is provided PDCPlugin will build only that product.
-When the argument is not provided PDCPlugin will now look for the first product to include PlaydateKit as a dependency.
--When no valid product is found an error will now be thrown instead of a crash.

-Resource copying is updated to only copy resources from the package product being built and it's dependencies.
-The build product name will now use the package->product->name instead of the package->name.