### PR TITLE
Add drawTextInRect

### DIFF
--- a/Sources/CPlaydate/include/CPlaydate.apinotes
+++ b/Sources/CPlaydate/include/CPlaydate.apinotes
@@ -244,8 +244,8 @@ Enumerators:
 - Name: kWrapWord
   SwiftName: word
 - Name: kAlignTextLeft
-SwiftName: left
+  SwiftName: left
 - Name: kAlignTextCenter
-SwiftName: center
+  SwiftName: center
 - Name: kAlignTextRight
-SwiftName: right
+  SwiftName: right

--- a/Sources/CPlaydate/include/CPlaydate.apinotes
+++ b/Sources/CPlaydate/include/CPlaydate.apinotes
@@ -40,6 +40,8 @@ Tags:
   EnumExtensibility: open
 - Name: SoundWaveform
   EnumExtensibility: open
+- Name: PDTextWrappingMode
+  EnumExtensibility: open
 Enumerators:
 - Name: kButtonLeft
   SwiftName: left
@@ -233,3 +235,9 @@ Enumerators:
   SwiftName: flippedY
 - Name: kBitmapFlippedXY
   SwiftName: flippedXY
+- Name: kWrapClip
+  SwiftName: clip
+- Name: kWrapCharacter
+  SwiftName: character
+- Name: kWrapWord
+  SwiftName: word

--- a/Sources/CPlaydate/include/CPlaydate.apinotes
+++ b/Sources/CPlaydate/include/CPlaydate.apinotes
@@ -42,6 +42,8 @@ Tags:
   EnumExtensibility: open
 - Name: PDTextWrappingMode
   EnumExtensibility: open
+- Name: PDTextAlignment
+  EnumExtensibility: open
 Enumerators:
 - Name: kButtonLeft
   SwiftName: left
@@ -241,3 +243,9 @@ Enumerators:
   SwiftName: character
 - Name: kWrapWord
   SwiftName: word
+- Name: kAlignTextLeft
+SwiftName: left
+- Name: kAlignTextCenter
+SwiftName: center
+- Name: kAlignTextRight
+SwiftName: right

--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -229,6 +229,8 @@ public enum Graphics {
     public typealias StringEncoding = PDStringEncoding
     public typealias PolygonFillRule = LCDPolygonFillRule
     public typealias SolidColor = LCDSolidColor
+    
+    public typealias TextWrap = PDTextWrappingMode
 
     public class BitmapTable {
         // MARK: Lifecycle

--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -598,6 +598,28 @@ public enum Graphics {
             CInt(point.y)
         ))
     }
+    
+    /// Draws the text in the given rectangle using the provided options. If no font has
+    /// been set with setFont, the default system font Asheville Sans 14 Light is used.
+    public static func drawTextInRect(
+        _ text: String,
+        in rect: Rect,
+        wrap: TextWrap = .clip,
+        aligned: TextAlignment = .left
+    ) {
+        graphics.drawTextInRect.unsafelyUnwrapped(
+            text,
+            text.utf8.count,
+            .kUTF8Encoding,
+            CInt(rect.x),
+            CInt(rect.y),
+            CInt(rect.width),
+            CInt(rect.height),
+            wrap,
+            aligned
+        )
+    }
+        
 
     /// Draws an ellipse inside the rectangle `rect` of width `lineWidth` (inset from the rectangle bounds).
     /// If `startAngle` != `endAngle`, this draws an arc between the given angles.

--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -231,6 +231,7 @@ public enum Graphics {
     public typealias SolidColor = LCDSolidColor
     
     public typealias TextWrap = PDTextWrappingMode
+    public typealias TextAlignment = PDTextAlignment
 
     public class BitmapTable {
         // MARK: Lifecycle


### PR DESCRIPTION
Adds the [drawTextInRect function](https://sdk.play.date/2.6.2/Inside%20Playdate%20with%20C.html#f-graphics.drawTextInRect) (and supporting enums) added in [SDK 2.6.0](https://sdk.play.date/changelog/#_2_6_0).