### PR TITLE
Implement linux compatibility

### DIFF
--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -328,6 +328,7 @@ struct ModuleBuildRequest {
 
         @Sendable func clangURL() throws -> URL {
             guard let url = [
+                swiftToolchain.path + "/usr/bin/clang",
                 try? context.tool(named: "clang").path.string
             ].compactMap({ $0 }).filter({
                 FileManager.default.fileExists(atPath: $0)


### PR DESCRIPTION
As promised! This implements all the changes that were made in the `linux` branch. I kept the structure of the file as-is though, without breaking out a Tools struct like what was done there.

I haven't tested this on a mac, I'd appreciate if someone could do that.

At some point between the work that was done in the linux branch and the current state of main, the `-lc` flag was dropped in invocations to `clang` (or maybe it was actually added specifically for linux support ?). I've added it back in because leaving it out yielded errors (in particular, the linker complained that it didn't now any `rand` function when compiling a game that used `array.randomElement()`).

In the end, the changes are minimal enough that merging this will allow for continued simultaneous development for both macOS and linux, without the need to separate the both.
