### PR TITLE
Fix Sound.LFO deinit

### DIFF
--- a/Sources/PlaydateKit/Core/Sound/Sound+LFO.swift
+++ b/Sources/PlaydateKit/Core/Sound/Sound+LFO.swift
@@ -8,7 +8,7 @@ public extension Sound {
 
         /// Returns a new LFO object, which can be used to modulate sounds. See ``Sound/LFO/setType(_:)`` for type values.
         public init(type: LFOType) {
-            super.init(pointer: lfo.newLFO.unsafelyUnwrapped(type).unsafelyUnwrapped)
+            super.init(pointer: lfo.newLFO.unsafelyUnwrapped(type).unsafelyUnwrapped, free: false)
         }
 
         deinit {

--- a/Sources/PlaydateKit/Core/Sound/Sound+Signal.swift
+++ b/Sources/PlaydateKit/Core/Sound/Sound+Signal.swift
@@ -4,12 +4,15 @@ public extension Sound {
     class Signal {
         // MARK: Lifecycle
 
-        init(pointer: OpaquePointer) {
+        init(pointer: OpaquePointer, free: Bool = true) {
             self.pointer = pointer
+            self.free = free
         }
 
         deinit {
-            signal.freeSignal.unsafelyUnwrapped(pointer)
+            if free {
+                signal.freeSignal.unsafelyUnwrapped(pointer)
+            }
         }
 
         // MARK: Public
@@ -31,5 +34,9 @@ public extension Sound {
         // MARK: Internal
 
         let pointer: OpaquePointer
+
+        // MARK: Private
+
+        private let free: Bool
     }
 }


### PR DESCRIPTION
Previously, Sound.Signal's deinit would try to free the same pointer again, crashing.