### PR TITLE
Fix simulator build on Xcode 26 / macOS 26

### DIFF
--- a/Toolsets/toolset_simulator_macos.json
+++ b/Toolsets/toolset_simulator_macos.json
@@ -1,7 +1,15 @@
 {
     "schemaVersion": "1.0",
+    "swiftCompiler": {
+        "extraCLIOptions": [
+            "-target", "arm64-apple-macos14",
+            "-Xfrontend", "-disable-implicit-concurrency-module-import",
+            "-Xfrontend", "-disable-implicit-string-processing-module-import"
+        ]
+    },
     "cCompiler": {
         "extraCLIOptions": [
+            "-target", "arm64-apple-macos14",
             "-DTARGET_SIMULATOR=1"
         ]
     },


### PR DESCRIPTION
Fix #148 

Xcode 26's macOS 26 SDK automatically imports _DarwinFoundation modules, which are incompatible with Embedded Swift mode. This causes build failures with errors like:

  error: module '_DarwinFoundation1' cannot be imported in embedded Swift mode

This fix explicitly sets the target to arm64-apple-macos14 in the simulator toolset, which avoids the macOS 26 SDK's implicit Foundation imports while still producing a working simulator binary.

Changes:
- Add swiftCompiler section with explicit target and flags to disable implicit module imports
- Add explicit target to cCompiler section