### PR TITLE
Fix build against Playdate SDK 3.1.1 (makeFontFromData datalength)

### DIFF
--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -338,10 +338,10 @@ public enum Graphics {
         }
 
         /// Returns a `Font` object wrapping the `LCDFontData` `data` comprising the contents (minus 16-byte header)
-        /// of an uncompressed pft file. `wide` corresponds to the flag in the header indicating whether the font contains
-        /// glyphs at codepoints above U+1FFFF.
-        public init?(data: OpaquePointer, wide: Bool) {
-            guard let pointer = graphics.makeFontFromData.unsafelyUnwrapped(data, wide ? 1 : 0) else {
+        /// of an uncompressed pft file. `length` is the size of `data` in bytes. `wide` corresponds to the flag in the
+        /// header indicating whether the font contains glyphs at codepoints above U+1FFFF.
+        public init?(data: OpaquePointer, length: Int, wide: Bool) {
+            guard let pointer = graphics.makeFontFromData.unsafelyUnwrapped(data, wide ? 1 : 0, CInt(length)) else {
                 return nil
             }
             self.pointer = pointer


### PR DESCRIPTION
Building PlaydateKit against Playdate SDK 3.1.1 currently fails:

```
Sources/PlaydateKit/Core/Graphics.swift:344:95: error: missing argument for parameter #3 in call
```

SDK 3.1.1 renamed the existing two-argument `graphics.makeFontFromData` to `makeFontFromData_deprecated` and added a new `makeFontFromData` taking an extra `datalength`:

```c
// pd_api_gfx.h:275
LCDFont* (*makeFontFromData_deprecated)(LCDFontData* data, int wide);
// pd_api_gfx.h:299
LCDFont* (*makeFontFromData)(LCDFontData* data, int wide, int datalength);
```

This adds a `length` parameter to `Graphics.Font.init?(data:wide:)` and forwards it as `datalength`. Source-breaking for callers of that initializer, but it's the only way to supply the new argument correctly.

For reference, 3.1.1 moved three other functions to `*_deprecated` (`lua.callFunction`, `synth.setGenerator`, `sequence.getTempo`); PlaydateKit doesn't call the first two, and `Sound+Sequence.swift` already expects the new `Float`-returning `getTempo`, so this initializer was the only break.

Verified by building a PlaydateKit game (simulator debug + release device configurations) against SDK 3.1.1 and running it in the Simulator.

Fixes https://github.com/finnvoor/PlaydateKit/issues/159