### PR TITLE
Support the Playdate Simulator's debugging tools

### DIFF
--- a/Examples/FlappySwift/Package.swift
+++ b/Examples/FlappySwift/Package.swift
@@ -33,10 +33,18 @@ let package = Package(
                     "-Xfrontend", "-disable-objc-interop",
                     "-Xfrontend", "-disable-stack-protector",
                     "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
                     "-Xcc", "-DTARGET_EXTENSION",
                     "-Xcc", "-I", "-Xcc", "\(playdateSDKPath)/C_API",
                 ]),
+                // Simulator (debug) builds keep the full DWARF that SwiftPM's `-g` produces so LLDB
+                // can inspect variables. Device (release) builds only need line tables, pinned to
+                // DWARF 4 because the Simulator's "Device - C" Sampler symbolizes through the
+                // Playdate SDK's `arm-none-eabi-addr2line`, which can't parse DWARF 5.
+                .unsafeFlags([
+                    "-Xfrontend", "-gline-tables-only",
+                    "-dwarf-version=4",
+                    "-Xcc", "-gdwarf-4",
+                ], .when(configuration: .release)),
             ],
         )
     ]

--- a/Examples/Pong/Package.swift
+++ b/Examples/Pong/Package.swift
@@ -33,10 +33,18 @@ let package = Package(
                     "-Xfrontend", "-disable-objc-interop",
                     "-Xfrontend", "-disable-stack-protector",
                     "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
                     "-Xcc", "-DTARGET_EXTENSION",
                     "-Xcc", "-I", "-Xcc", "\(playdateSDKPath)/C_API",
                 ]),
+                // Simulator (debug) builds keep the full DWARF that SwiftPM's `-g` produces so LLDB
+                // can inspect variables. Device (release) builds only need line tables, pinned to
+                // DWARF 4 because the Simulator's "Device - C" Sampler symbolizes through the
+                // Playdate SDK's `arm-none-eabi-addr2line`, which can't parse DWARF 5.
+                .unsafeFlags([
+                    "-Xfrontend", "-gline-tables-only",
+                    "-dwarf-version=4",
+                    "-Xcc", "-gdwarf-4",
+                ], .when(configuration: .release)),
             ],
         )
     ]

--- a/Examples/Xkpd/Package.swift
+++ b/Examples/Xkpd/Package.swift
@@ -38,10 +38,18 @@ let package = Package(
                     "-Xfrontend", "-disable-objc-interop",
                     "-Xfrontend", "-disable-stack-protector",
                     "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
                     "-Xcc", "-DTARGET_EXTENSION",
                     "-Xcc", "-I", "-Xcc", "\(playdateSDKPath)/C_API",
                 ]),
+                // Simulator (debug) builds keep the full DWARF that SwiftPM's `-g` produces so LLDB
+                // can inspect variables. Device (release) builds only need line tables, pinned to
+                // DWARF 4 because the Simulator's "Device - C" Sampler symbolizes through the
+                // Playdate SDK's `arm-none-eabi-addr2line`, which can't parse DWARF 5.
+                .unsafeFlags([
+                    "-Xfrontend", "-gline-tables-only",
+                    "-dwarf-version=4",
+                    "-Xcc", "-gdwarf-4",
+                ], .when(configuration: .release)),
             ],
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,37 @@ let playdateSDKPath: String = if let path = Context.environment["PLAYDATE_SDK_PA
     "\(Context.environment["HOME"]!)/Developer/PlaydateSDK/"
 }
 
+/// Flags shared by every Embedded Swift target in this package.
+///
+/// Debug builds are the ones that end up in `pdex.dylib`, and they keep the full
+/// DWARF that SwiftPM's `-g` produces so LLDB can inspect variables while the
+/// game runs in the Playdate Simulator.
+///
+/// Release builds are the ones that end up in `pdex.elf`, and only need line
+/// tables. They are pinned to DWARF 4 because the Simulator's "Device - C"
+/// Sampler symbolizes samples by shelling out to the Playdate SDK's
+/// `arm-none-eabi-addr2line`, which ships with binutils 2.32 and fails to parse
+/// the DWARF 5 that Clang emits by default.
+let embeddedSwiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("Embedded"),
+    .unsafeFlags([
+        "-whole-module-optimization",
+        "-Xfrontend", "-disable-objc-interop",
+        "-Xfrontend", "-disable-stack-protector",
+        "-Xfrontend", "-function-sections",
+        "-Xcc", "-DTARGET_EXTENSION",
+        "-I", "\(playdateSDKPath)/C_API"
+    ]),
+    .unsafeFlags(
+        [
+            "-Xfrontend", "-gline-tables-only",
+            "-dwarf-version=4",
+            "-Xcc", "-gdwarf-4"
+        ],
+        .when(configuration: .release)
+    )
+]
+
 let package = Package(
     name: "PlaydateKit",
     platforms: [.macOS(.v14)],
@@ -21,35 +52,13 @@ let package = Package(
         .target(
             name: "PlaydateKit",
             dependencies: ["CPlaydate"],
-            swiftSettings: [
-                .enableExperimentalFeature("Embedded"),
-                .unsafeFlags([
-                    "-whole-module-optimization",
-                    "-Xfrontend", "-disable-objc-interop",
-                    "-Xfrontend", "-disable-stack-protector",
-                    "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
-                    "-Xcc", "-DTARGET_EXTENSION",
-                    "-I", "\(playdateSDKPath)/C_API"
-                ]),
-            ]
+            swiftSettings: embeddedSwiftSettings
         ),
         .target(
             name: "CrankIndicator",
             dependencies: ["PlaydateKit"],
             exclude: ["Resources"],
-            swiftSettings: [
-                .enableExperimentalFeature("Embedded"),
-                .unsafeFlags([
-                    "-whole-module-optimization",
-                    "-Xfrontend", "-disable-objc-interop",
-                    "-Xfrontend", "-disable-stack-protector",
-                    "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
-                    "-Xcc", "-DTARGET_EXTENSION",
-                    "-I", "\(playdateSDKPath)/C_API"
-                ]),
-            ]
+            swiftSettings: embeddedSwiftSettings
         ),
         .target(
             name: "CPlaydate",
@@ -57,14 +66,15 @@ let package = Package(
                 .unsafeFlags([
                     "-DTARGET_EXTENSION",
                     "-I", "\(playdateSDKPath)/C_API"
-                ])
+                ]),
+                // See `embeddedSwiftSettings` for why the device build is pinned to DWARF 4.
+                .unsafeFlags(["-gdwarf-4"], .when(configuration: .release))
             ]
         ),
         .plugin(
             name: "PDCPlugin",
             capability: .command(intent:
-                .custom(verb: "pdc", description: "Runs the Playdate compiler")
-            )
+                .custom(verb: "pdc", description: "Runs the Playdate compiler"))
         ),
         .plugin(
             name: "RenamePlugin",

--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -55,7 +55,9 @@ import PackagePlugin
         #endif
     }
 
-    var playdateSDKURL: URL { get throws { try URL(filePath: playdateSDKPath) } }
+    var playdateSDKURL: URL {
+        get throws { try URL(filePath: playdateSDKPath) }
+    }
 
     func performCommand(context: PluginContext, arguments: [String]) async throws {
         let arguments = Arguments(arguments)
@@ -71,7 +73,19 @@ import PackagePlugin
                 --device-only                             Build a device-only executable suitable for distribution
                 --simulator-only                          Build a simulator-only executable for quick testing
                 --extra-device-o-files-build-dirs <dirs>  Add more built directories to device `.o` files search (comma-separated)
+                --no-debug-symbols                        Skip all debug symbol post processing
+                --no-dsym                                 Don't copy the simulator dSYM bundle into the pdx
             -v, --verbose                                 Increase verbosity to include informational output
+
+            DEBUGGING
+
+            By default `pdc` publishes the debug info the Playdate Simulator's tools need:
+
+            * The simulator `dSYM` bundle is copied next to `pdex.dylib` inside the pdx, which is
+              where LLDB looks for it. Without this, breakpoints in a running game don't resolve.
+            * An unstripped `<Product>.elf` is written next to the pdx, ready to be selected in the
+              Sampler's "Choose Game" prompt when sampling `Device - C`. `pdc` itself only keeps the
+              stripped `pdex.bin`.
             """)
             return
         }
@@ -83,6 +97,8 @@ import PackagePlugin
         let deviceOnly = arguments.hasFlag(named: "device-only", allowShort: false)
         let simulatorOnly = arguments.hasFlag(named: "simulator-only", allowShort: false)
         let extraDeviceOFilesBuildDirs = arguments.value(for: "extra-device-o-files-build-dirs", allowShort: false)
+        let debugSymbols = !arguments.hasFlag(named: "no-debug-symbols", allowShort: false)
+        let copyDSYM = debugSymbols && !arguments.hasFlag(named: "no-dsym", allowShort: false)
 
         let product: PackagePlugin.Product? = if let productName {
             context.package.products.first {
@@ -116,9 +132,10 @@ import PackagePlugin
             )
         }
 
+        var simulatorArtifact: URL?
         if !deviceOnly {
             print("Building for simulator...")
-            try buildSimulator(
+            simulatorArtifact = try buildSimulator(
                 context: context,
                 product: product,
                 configuration: .debug,
@@ -139,6 +156,18 @@ import PackagePlugin
             product: product,
             verbose: verbose
         )
+
+        if debugSymbols {
+            print("Post processing debug symbols...")
+            try postProcessDebugSymbols(
+                context: context,
+                product: product,
+                simulatorArtifact: simulatorArtifact,
+                copyDSYM: copyDSYM,
+                includesDevice: !simulatorOnly,
+                verbose: verbose
+            )
+        }
 
         let buildDuration = (Date().timeIntervalSince(startTime))
             .formatted(.number.precision(.fractionLength(2)))
@@ -178,7 +207,9 @@ import PackagePlugin
         )
 
         guard result.succeeded else {
-            if !verbose { print(result.logText) }
+            if !verbose {
+                print(result.logText)
+            }
             throw Error.buildFailed
         }
 
@@ -230,12 +261,13 @@ import PackagePlugin
         ])
     }
 
-    func buildSimulator(
+    /// - Returns: The URL of the built dylib in the SwiftPM build directory.
+    @discardableResult func buildSimulator(
         context: PluginContext,
         product: PackagePlugin.Product,
         configuration: PackageManager.BuildConfiguration,
         verbose: Bool
-    ) throws {
+    ) throws -> URL {
         let simulatorParameters = try PackageManager.BuildParameters(
             configuration: configuration,
             logging: verbose ? .verbose : .concise,
@@ -248,7 +280,9 @@ import PackagePlugin
         )
 
         guard result.succeeded else {
-            if !verbose { print(result.logText) }
+            if !verbose {
+                print(result.logText)
+            }
             throw Error.buildFailed
         }
 
@@ -261,6 +295,62 @@ import PackagePlugin
                 .appending(component: "pdex")
                 .appendingPathExtension(artifact.url.pathExtension)
         )
+
+        return artifact.url
+    }
+
+    /// Makes the built artifacts usable by the Playdate Simulator's Sampler, Malloc Log and by LLDB.
+    ///
+    /// This runs after `pdc` so that `pdc` always sees pristine input: the pdx contents are patched
+    /// in place instead.
+    func postProcessDebugSymbols(
+        context: PluginContext,
+        product: PackagePlugin.Product,
+        simulatorArtifact: URL?,
+        copyDSYM: Bool,
+        includesDevice: Bool,
+        verbose: Bool
+    ) throws {
+        let fileManager = FileManager.default
+        let pdx = context.pluginWorkDirectoryURL
+            .appending(component: product.name)
+            .appendingPathExtension("pdx")
+
+        // LLDB finds a dSYM that sits next to the binary it belongs to. `pdex.dylib` on macOS,
+        // `pdex.so` on Linux.
+        let library = pdx.appending(component: "pdex")
+            .appendingPathExtension(simulatorArtifact?.pathExtension ?? "dylib")
+        if copyDSYM, let simulatorArtifact {
+            let dSYM = simulatorArtifact.appendingPathExtension("dSYM")
+            if fileManager.fileExists(atPath: dSYM.path(percentEncoded: false)) {
+                let destination = library.appendingPathExtension("dSYM")
+                if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+                    try fileManager.removeItem(at: destination)
+                }
+                try fileManager.copyItem(at: dSYM, to: destination)
+                if verbose {
+                    print("Copied \(dSYM.lastPathComponent) into \(pdx.lastPathComponent)")
+                }
+            }
+        }
+
+        // The Sampler asks for a `.elf` when sampling device performance in C code. `pdc` only keeps
+        // the stripped `pdex.bin`, so publish a copy of the unstripped ELF next to the pdx.
+        let builtELF = context.pluginWorkDirectoryURL
+            .appending(component: "Source")
+            .appending(component: "pdex.elf")
+        if includesDevice, fileManager.fileExists(atPath: builtELF.path(percentEncoded: false)) {
+            let destination = context.pluginWorkDirectoryURL
+                .appending(component: product.name)
+                .appendingPathExtension("elf")
+            if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.copyItem(at: builtELF, to: destination)
+            if verbose {
+                print("Wrote \(destination.lastPathComponent) for the Sampler")
+            }
+        }
     }
 
     func copyResources(
@@ -330,7 +420,9 @@ import PackagePlugin
         task.arguments = arguments
         task.standardOutput = FileHandle.standardOutput
         task.standardError = FileHandle.standardError
-        if verbose { task.print() }
+        if verbose {
+            task.print()
+        }
         try task.run()
         task.waitUntilExit()
         guard task.terminationReason == .exit, task.terminationStatus == 0 else {

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ final class Game: PlaydateGame {
 }
 ```
 
+## Debugging
+
+`swift package pdc` publishes the debug info the Playdate Simulator's built-in tools need:
+
+- Simulator builds keep full debug info and the `dSYM` bundle is copied into the pdx next to `pdex.dylib`, so **LLDB** can attach to the running Simulator, hit breakpoints, and inspect variables.
+- An unstripped `<Product>.elf` is written next to the pdx for the **Sampler**'s `Device - C` mode, and device builds emit DWARF 4 so the SDK's `arm-none-eabi-addr2line` can resolve source lines.
+
+See [Debugging](https://finnvoor.github.io/PlaydateKit/documentation/playdatekit/debugging) for the full rundown of which Simulator tools work with a compiled Swift game.
+
 ## Contributing
 
 I'm happy to accept contributions on this project, whether it's bug fixes, implementing missing features, or opening an issue. Please try to follow the existing conventions/style in the project.

--- a/Sources/PlaydateKit/Core/Graphics.swift
+++ b/Sources/PlaydateKit/Core/Graphics.swift
@@ -861,8 +861,13 @@ public enum Graphics {
 
     /// Only valid in the Simulator; function returns nil on device. Returns the debug framebuffer as a bitmap.
     /// White pixels drawn in the image are overlaid on the display in 50% transparent red.
+    ///
+    /// The Simulator owns this bitmap and reuses it every frame, so it must never be freed. Prefer
+    /// ``Debug/draw(_:)``, which handles pushing and popping the drawing context for you.
     public static func getDebugBitmap() -> Bitmap? {
-        graphics.getDebugBitmap.unsafelyUnwrapped().map { Bitmap(pointer: $0) }
+        // `free: false` is essential: this is the Simulator's own debug framebuffer, and freeing it
+        // corrupts the Simulator's heap and takes the whole process down a few frames later.
+        graphics.getDebugBitmap.unsafelyUnwrapped().map { Bitmap(pointer: $0, free: false) }
     }
 
     /// Returns the raw bits in the display buffer, the last completed frame.

--- a/Sources/PlaydateKit/Documentation.docc/Documentation.md
+++ b/Sources/PlaydateKit/Documentation.docc/Documentation.md
@@ -14,6 +14,10 @@ Create games for Playdate using Swift.
 - <doc:Building-the-Template>
 - ``PlaydateGame``
 
+### Debugging
+
+- <doc:Debugging>
+
 ### Essentials
 
 - ``Display``

--- a/Sources/PlaydateKit/Documentation.docc/Essentials/Debugging.md
+++ b/Sources/PlaydateKit/Documentation.docc/Essentials/Debugging.md
@@ -1,0 +1,117 @@
+# Debugging
+
+Use the Playdate Simulator's built in debugging tools with a PlaydateKit game.
+
+## Overview
+
+The Simulator's debugging tools were built with Lua in mind, and several of them need debug info that
+a PlaydateKit build has to go out of its way to publish. `swift package pdc` does that automatically.
+
+This article covers which tools work with a compiled Swift game, which don't, and why.
+
+## Setting breakpoints with LLDB
+
+Simulator builds keep the full DWARF that SwiftPM's `-g` produces, and `swift package pdc` copies the
+`dSYM` bundle into the pdx next to `pdex.dylib` — the one place LLDB looks for it. Attach to the
+running Simulator:
+
+```console
+$ lldb -p $(pgrep -f 'MacOS/Playdate Simulator')
+(lldb) breakpoint set --file Game.swift --line 111
+Breakpoint 1: where = pdex.dylib`Ball.update() + 100 at Game.swift:111:19
+```
+
+Breakpoints, backtraces across the Swift/C boundary, and variable inspection all work:
+
+```text
+(lldb) thread backtrace
+  * frame #0: pdex.dylib`Ball.update() at Game.swift:111:19
+    frame #1: pdex.dylib`closure #1 in Sprite.Sprite.init(...) at Sprite.swift:21:24
+    frame #3: Playdate Simulator`pc_sprite_updateSprites + 392
+    frame #6: pdex.dylib`Game.update() at Game.swift:47:20
+
+(lldb) frame variable
+(Pong.Ball) self = 0x00000072e8807700 {
+  velocity = (x = 4, y = 5)
+}
+```
+
+The Simulator also supports the
+[debug adapter protocol](https://microsoft.github.io/debug-adapter-protocol/), so editors like Nova
+can drive this too.
+
+Pass `--no-dsym` to keep the bundle out of the pdx.
+
+## Profiling with the Sampler
+
+The Sampler can sample `Simulator - Lua`, `Device - Lua` and `Device - C`. A PlaydateKit game is C,
+so **`Device - C`**, with the game running on hardware, is the mode to use.
+
+> Important: There is no `Simulator - C` option. Native code cannot be sampled in the Simulator at
+all — this is a Simulator limitation, not something a game can opt into.
+
+`Device - C` symbolizes by shelling out to the SDK's `arm-none-eabi-addr2line` and asks you to choose
+a game. Select the **`.elf` file**, not the pdx bundle. `pdc` only keeps the stripped `pdex.bin`
+inside the pdx, so `swift package pdc` writes an unstripped copy next to it:
+
+```text
+.build/plugins/PDCPlugin/outputs/MyGame.pdx
+.build/plugins/PDCPlugin/outputs/MyGame.elf   ← choose this one
+```
+
+Device builds are also pinned to DWARF 4. The `arm-none-eabi-addr2line` that ships with the Playdate
+SDK is binutils 2.32 and cannot parse the DWARF 5 that Clang emits by default — with DWARF 5 it fails
+outright and every sample resolves to no source location.
+
+> Note: The Sampler runs `addr2line -f` without `-C`, and reads function names out of DWARF, so Swift
+frames appear as mangled names like `$e4Pong4BallC6updateyyF` alongside the correct file and line.
+Run a name through `swift demangle` to read it.
+
+## Inspecting memory with the Malloc Log
+
+**View ▸ Show Malloc Log** shows the memory your game allocates. Because PlaydateKit routes the
+Embedded Swift runtime's allocations through the Playdate allocator, every Swift object appears here.
+
+1. Choose **Playdate ▸ Malloc Pool ▸ 16 MB** — the Malloc Log needs pooling to be active.
+2. Choose **View ▸ Show Malloc Log**.
+
+The window reports total heap used, active bytes and a live item count, and lists every allocation by
+address and size. The `Source` column is not populated in SDK 3.1.1, for Lua or C, so allocations
+can't be attributed back to the code that made them.
+
+> Warning: While Malloc Pool is enabled the Simulator retains every allocation in order to show
+history, so its own memory use grows without bound. Only turn it on while investigating.
+
+**Lua Memory** is Lua-only and stays empty for a PlaydateKit game.
+
+## Drawing debug overlays
+
+The Simulator composites a separate debug framebuffer over the display in 50% transparent red.
+``Graphics/getDebugBitmap()`` returns it, and it works with the normal drawing API by pushing it as
+the current context:
+
+```swift
+if let debugBitmap = Graphics.getDebugBitmap() {
+    Graphics.pushContext(debugBitmap)
+    Graphics.clear(color: .black)
+    for enemy in enemies {
+        Graphics.drawRect(enemy.hitbox, color: .white)
+    }
+    Graphics.popContext()
+}
+```
+
+Only white pixels show up in the overlay. Toggle it with **View ▸ Enable Debug Drawing**. On device
+`getDebugBitmap()` returns `nil`, so this is safe to leave in shipping code.
+
+> Important: The Simulator owns this bitmap and reuses it every frame — never free it. PlaydateKit
+returns it with ownership disabled for exactly this reason.
+
+## Tools that need nothing from your game
+
+- **Console** — ``System/log(_:)`` and Swift's `print` both write here. The input field also accepts
+  `!msg <message>`, delivered to ``System/setSerialMessageCallback(callback:)``.
+- **Highlight Screen Updates** and **Show Sprite Collision Rects** work automatically through the
+  sprite system that ``Sprite`` wraps.
+- **Device Info** graphs performance and memory of a connected device.
+- **Event Recorder** records and replays input.


### PR DESCRIPTION
Three of the Simulator's built-in debugging tools didn't work with a PlaydateKit game.

**LLDB** couldn't resolve breakpoints: `-gline-tables-only` was applied to every configuration, and the `dSYM` never left the SwiftPM build directory. Simulator builds now keep full DWARF, and `pdc` copies the `dSYM` into the pdx next to `pdex.dylib`.

**Sampler** (`Device - C`) resolved no source lines: it shells out to the SDK's `arm-none-eabi-addr2line`, which is binutils 2.32 and can't parse Clang's default DWARF 5. Device builds now emit DWARF 4, and an unstripped `<Product>.elf` is written next to the pdx since `pdc` only keeps `pdex.bin`.

**Debug drawing** crashed the Simulator: `Graphics.getDebugBitmap()` wrapped the Simulator's own framebuffer in an owning `Bitmap`, so releasing it freed memory the Simulator reuses every frame.

Opt out with `--no-debug-symbols` / `--no-dsym`.
